### PR TITLE
CAN mode and bitrate configuration in Ansible

### DIFF
--- a/ansible/avena/roles/can/files/systemd/can@.service
+++ b/ansible/avena/roles/can/files/systemd/can@.service
@@ -4,7 +4,8 @@ Description=Enable %I interface
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/sbin/ip link set %I type can bitrate 250000
+EnvironmentFile=/etc/can.conf
+ExecStart=/sbin/ip link set %I type can bitrate $%IBITRATE $%IOPTIONS 
 ExecStart=/sbin/ip link set %I up
 ExecStart=/usr/bin/bash -c 'echo "enabled" > /sys/class/net/%I/device/power/wakeup'
 ExecStop=/sbin/ip link set %I down

--- a/ansible/avena/roles/can/tasks/main.yml
+++ b/ansible/avena/roles/can/tasks/main.yml
@@ -21,6 +21,15 @@
         mode: "0644"
       notify: reload udev
 
+    - name: ensure can interface bitrate and options are set
+      become: yes
+      copy:
+        dest: /etc/can.conf
+        src: can.j2
+        owner: root
+        group: root
+        mode: "0644"
+ 
     - name: ensure can interfaces are started
       become: yes
       systemd:

--- a/ansible/avena/roles/can/templates/config/can.j2
+++ b/ansible/avena/roles/can/templates/config/can.j2
@@ -1,0 +1,4 @@
+{% for interface in oats_can_interfaces %}
+{{ interface }}_BITRATE={{ interface_bitrate }}
+{{ interface }}_OPTIONS={{ interface_options }}
+{% endfor %}

--- a/services/cell_logger/cell_logger.py
+++ b/services/cell_logger/cell_logger.py
@@ -95,6 +95,8 @@ signal_gauge = Gauge('avena_cell_signal_power', 'Received cell signal power')
 
 if((log_env == 'DB') or (log_env == 'DB,CSV') or (log_env == 'CSV,DB')):
 
+    import postgres
+
     global db
 
     connection_url = ('postgresql://' + os.environ['db_user'] + ':' + 
@@ -119,7 +121,7 @@ if((log_env == 'DB') or (log_env == 'DB,CSV') or (log_env == 'CSV,DB')):
             migrate_data => TRUE);""")
 
     print("Finished setting up tables")
- 
+
 #Initialize DBus system bus
 
 bus = dbus.SystemBus()


### PR DESCRIPTION
This PR adds bitrate configuration for each CAN interface. This helps to properly configure the bitrate, specially in John Deere machines, where implement and tractor bus run at different speeds. Also adds the option to enable _listen-only_ mode to avoid locking the CAN bus when the bitrate is set to a different value.