### PR TITLE
Updates to Github Actions for release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,8 +54,8 @@ jobs:
 
           # Release version is just the release number
           if [[ $GITHUB_REF == refs/heads/release/* ]]; then
-            VERSION=${GITHUB_REF#refs/heads/release/}
-            RELEASE=true
+              VERSION=${GITHUB_REF#refs/heads/release/}
+              RELEASE=true
 
           # Branch version is branch name (with '/' -> '-')
           elif [[ $GITHUB_REF == refs/heads/* ]]; then
@@ -78,9 +78,14 @@ jobs:
           TAGS="${DOCKER_IMAGE}:${VERSION}"
 
           if [[ $RELEASE ]]; then
-            MINOR=${VERSION%.*}
-            MAJOR=${MINOR.*}
-            TAGS="$TAGS,${DOCKER_IMAGE}:${MAJOR},${DOCKER_IMAGE}:${MINOR},${DOCKER_IMAGE}:latest"
+            if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+              MINOR=${VERSION%.*}
+              MAJOR=${MINOR.*}
+              TAGS="$TAGS,${DOCKER_IMAGE}:${MAJOR},${DOCKER_IMAGE}:${MINOR},${DOCKER_IMAGE}:latest"
+            else
+              echo ::error ::Version does not follow semantic versioning. Stopping.
+              exit 1
+            fi
           fi
 
           if [ "${{ github.event_name }}" = "push" ]; then

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,24 +1,11 @@
-name: docker buildx
+name: Build and push Avena containers
 
 on:
   push:
-    branches:
-      - '*'
-    tags:
-      - '*'
   pull_request:
-    branches:
-      - '*'
-    tags:
-      - '*'
-
-env:
-  DOCKER_IMAGE_PROD: "isoblue"
-  DOCKER_IMAGE_DEV: "isoblue"
-  DOCKER_PLATFORMS: "linux/amd64,linux/arm/v7"
 
 jobs:
-  docker:
+  build-and-push-services:
     strategy:
       matrix:
         service:
@@ -26,13 +13,27 @@ jobs:
           - oada_upload
           - cell_logger
           - can_watchdog
+
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up docker buildx
-        uses: crazy-max/ghaction-docker-buildx@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+
+      - name: Builder instance name
+        run: echo ${{ steps.buildx.outputs.name }}
+
+      - name: Available platforms
+        run: echo ${{ steps.buildx.outputs.platforms }}
 
       - name: Cache docker layers
         uses: actions/cache@v2
@@ -47,64 +48,79 @@ jobs:
       - name: Prepare
         id: prepare
         run: |
-          echo 'Porcessing git ref:' $GITHUB_REF
-          
+          echo 'Processing git ref:' $GITHUB_REF
+
           DOCKER_IMAGE=isoblue/${{ matrix.service }}
 
-          if [[ $GITHUB_REF == refs/tags/* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/}
-          
-          elif [[ $GITHUB_REF == refs/heads/* ]]; then
-            VERSION=${GITHUB_REF#refs/heads/}
+          # Release version is just the release number
+          if [[ $GITHUB_REF == refs/heads/release/* ]]; then
+            VERSION=${GITHUB_REF#refs/heads/release/}
+            RELEASE=true
 
-            # Make default branch the latest tag
-            if [[ $VERSION == ${{ github.event.repository.default_branch }} ]]; then
-              VERSION='latest'
+          # Branch version is branch name (with '/' -> '-')
+          elif [[ $GITHUB_REF == refs/heads/* ]]; then
+            VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
+
+            # Expect for the default_branch, which gets version "next"
+            if [ "$VERSION" == "${{ github.event.repository.default_branch }}" ]; then
+              VERSION=next
             fi
 
-          elif [[ $GITHUB_REF == refs/pull/*/merge ]]; then
-            VERSION=${GITHUB_REF#refs/pull/}
-            VERSION="pr-${VERSION%/merge}"
-            
-          elif [[ $GITHUB_REF == refs/remotes/pull/*/merge ]]; then
-            VERSION=${GITHUB_REF#refs/remotes/pull/}
-            VERSION="pr-${VERSION%/merge}"
-            
+          # PR versions are pr-<github pr number>
+          elif [[ $GITHUB_REF == refs/pull/* ]]; then
+            VERSION=pr-${{ github.event.number }}
+
           else
             echo ::error ::Can not determine version of service -- unexpected job trigger? Stopping.
             exit 1
           fi
 
-          echo ::set-output name=docker_image::${DOCKER_IMAGE}
+          TAGS="${DOCKER_IMAGE}:${VERSION}"
+
+          if [[ $RELEASE ]]; then
+            MINOR=${VERSION%.*}
+            MAJOR=${MINOR.*}
+            TAGS="$TAGS,${DOCKER_IMAGE}:${MAJOR},${DOCKER_IMAGE}:${MINOR},${DOCKER_IMAGE}:latest"
+          fi
+
+          if [ "${{ github.event_name }}" = "push" ]; then
+            TAGS="$TAGS,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
+          fi
+
           echo ::set-output name=version::${VERSION}
-          echo ::set-output name=buildx_args:: \
-            --cache-from "type=local,src=/tmp/.buildx-cache" \
-            --cache-to "type=local,dest=/tmp/.buildx-cache" \
-            --platform ${DOCKER_PLATFORMS} \
-            --build-arg VERSION=${VERSION} \
-            --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
-            --build-arg GIT_REF=${GITHUB_SHA::8} \
-            --tag ${DOCKER_IMAGE}:${VERSION} \
-            ${TAGS} --file services/${{ matrix.service }}/Dockerfile ./services/${{ matrix.service }}
+          echo ::set-output name=tags::${TAGS}
+          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
 
-      - name: Docker Login
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        run: |
-          echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
+          echo ${{ github.event.repository.license }}
 
-      - name: Docker buildx
-        if: success()
-        run: |
-          docker buildx build --output "type=image,push=true" ${{ steps.prepare.outputs.buildx_args }}
 
-      - name: Docker check manifest
-        if: success()
-        run: |
-          docker run --rm mplatform/mquery ${{ steps.prepare.outputs.docker_image }}:${{ steps.prepare.outputs.version }}
+      - name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Clear
-        if: always()
-        run: |
-          rm -f ${HOME}/.docker/config.json
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: services/${{ matrix.service }}
+          file: services/${{ matrix.service }}/Dockerfile
+          platforms: linux/amd64,linux/arm/v7
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.prepare.outputs.tags }}
+          build-args: |
+            VERSION=${{ steps.prepare.outputs.version }}
+            BUILD_DATE=${{ steps.prepare.outputs.created }}
+            GIT_REF=${{ github.sha }}
+          labels: |
+            org.opencontainers.image.title=${{ matrix.service }}
+            org.opencontainers.image.description=An ISOBlue Avena Service
+            org.opencontainers.image.url=${{ github.event.repository.html_url }}
+            org.opencontainers.image.source=${{ github.event.repository.clone_url }}
+            org.opencontainers.image.version=${{ steps.prepare.outputs.version }}
+            org.opencontainers.image.created=${{ steps.prepare.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache


### PR DESCRIPTION
This PR contains

1. major version upgrades of the underlying docker github actions. 

It is all much nicer now :tada: 

2. updates to the tagging scheme.

I *think* this is right:

- Things pushed to a branch like `release/<version>` are tagged `:<version>`, `:<major>`, `:<minor>`, and `:latest`. Where `<major>` is 1 and `<minor>` is 1.3 for a `<version>` of `1.3.24`.

- Things pushed to `master` branch (or really the GitHub "default branch" setting) are tagged with `:next`.

- Things pushed to any other branch are tagged with `:<branch-name>` where `<branch-name>` is the git branch name with `/` replaced by `-`. 

- Pull requests are tagged with `:pr-<pr-num>` where `<pr-num>` is the GitHub pull request number

- All pushes are ALSO tagged with `sha-<short-sha>` where `<short-sha>` is the first 8 characters of the git commit SHA.

With this setup, you can track a version (full, major, or minor), a branch, the current next-to-be-released, or a specific commit/push. 

These rules are simple to change (just a bash script). So we can discuss and modify as needed.

3. Added dependabot to notify us of action updates