### PR TITLE
Remove "v" from release format

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
           TAGS="${DOCKER_IMAGE}:${VERSION}"
 
           if [[ $RELEASE ]]; then
-            if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+            if [[ $VERSION =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
               MINOR=${VERSION%.*}
               MAJOR=${MINOR.*}
               TAGS="$TAGS,${DOCKER_IMAGE}:${MAJOR},${DOCKER_IMAGE}:${MINOR},${DOCKER_IMAGE}:latest"


### PR DESCRIPTION
I thought I got this fixed up in #86, but it appears I forgot to push the commit.

We will need to delete release/0.1.0 and recreate it after this is merged.