### PR TITLE
GPS2TSDB Health Check

### DIFF
--- a/services/gps2tsdb/Dockerfile
+++ b/services/gps2tsdb/Dockerfile
@@ -38,6 +38,10 @@ COPY --from=builder /opt/venv /opt/venv
 # Make sure we use the virtualenv
 ENV PATH="/opt/venv/bin:$PATH"
 
+# Copy health check script
+COPY healthcheck.py .
+HEALTHCHECK CMD ["python", "./healthcheck.py"]
+
 # Copy script over and run
 COPY gps.py .
 CMD [ "python", "./gps.py" ]

--- a/services/gps2tsdb/healthcheck.py
+++ b/services/gps2tsdb/healthcheck.py
@@ -1,0 +1,25 @@
+#!/usr/bin/python3
+import postgres
+import sys
+import os
+import datetime
+
+threshold = 5
+
+connectionurl='postgresql://' + os.environ['db_user'] + ':' + os.environ['db_password'] + '@postgres:' + os.environ['db_port'] + '/' + os.environ['db_database']
+db = postgres.Postgres(url=connectionurl)
+
+rst = db.one("SELECT * FROM gps ORDER BY time DESC LIMIT 1;")
+
+if rst == None:
+    print("Database has the wrong schema or no data");
+    sys.exit(1)
+
+lastupdate = rst[0]
+tdelta = datetime.datetime.now(lastupdate.tzinfo) - lastupdate
+sdelta = tdelta.total_seconds()
+if sdelta > threshold:
+  print('Database was last updated', sdelta, 'seconds ago, something is wrong ( threshold:', threshold, 's )');
+  sys.exit(1)
+
+print('Database was last updated', sdelta, 'seconds ago, everything is normal ( threshold:', threshold, 's )');


### PR DESCRIPTION
Start of working on #87. This script checks the database and if it does not find a gps point that is less than 5 seconds old it fails

Using the default values for health checks (wait 30s to start checking, check every 30s, wait for 3 consecutive fails to change to unhealthy)

Should be trivial to put this on all the loggers. A health check for something like `oada_upload` will be another animal though

Examples:
You can check the monitor via `docker inspect`:
```
avena@avena-apalis-dev05:~$ docker inspect gps2tsdb_gps2tsdb_1 | head -n 50
[...]
            "Health": {
                "Status": "healthy",
                "FailingStreak": 0,
                "Log": [
                    {
                        "Start": "2020-10-02T22:16:22.978499033Z",
                        "End": "2020-10-02T22:16:24.287617231Z",
                        "ExitCode": 0,
                        "Output": "Database was last updated 0.994602 seconds ago, everything is normal ( threshold: 5 s )\n"
                    },
                    {
                        "Start": "2020-10-02T22:16:54.310686141Z",
                        "End": "2020-10-02T22:16:55.654777704Z",
                        "ExitCode": 0,
                        "Output": "Database was last updated 0.357015 seconds ago, everything is normal ( threshold: 5 s )\n"
                    },
     [..]
```
Health status in `docker ps`
```
avena@avena-apalis-dev05:~$ docker ps
CONTAINER ID        IMAGE                               COMMAND                  CREATED              STATUS                        PORTS                      NAMES
847d17f8d52c        gps2tsdb_gps2tsdb                   "python ./gps.py"        About a minute ago   Up About a minute (healthy)   0.0.0.0:10001->10001/tcp   gps2tsdb_gps2tsdb_1
```

Hopefully this will help our automated test scripts check the if the containers are performing normally