### PR TITLE
Inital draft of codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,40 @@
+# Code Owners Declaration
+# This file defines the code owners for files in this repository
+# See documentation here: https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+# Fabio Castilblanco is the leader of this project and will be the default 
+# reviewer if no one else is assigned
+* facastiblancor
+
+
+# Aaron Neustedter wrote the contributing.md and Andrew Balmos wrote the other
+# misc files in root
+CONTIBUTING.md aaron97neu
+.markdownlink.json abalmos
+notes.md abalmos
+notes.md abalmos
+
+# Andrew intially created all the files in .github with some additions by Aaron
+.github abalmos
+.github/CODEOWNERS aaron97neu
+
+# Andrew initally wrote the ansible scripts, with some additions by Aaron
+ansible abalmos
+ansible/avena/roles/docker/files aaron97neu
+
+# Fabio is responsible for the development of the shield and related hardware
+hardware facastiblancor
+
+# Andrew intially the installers
+installers aaron97neu
+
+Fabio wrote the cell/can logger containers
+services/can_logger
+services/cell_logger
+services/socketcand
+
+# Aaron wrote the gps, db, and oada related containers
+services/can_watchdog
+services/gps2tsdb
+services/oada_upload
+services/postgres

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,13 +9,13 @@
 
 # Aaron Neustedter wrote the contributing.md and Andrew Balmos wrote the other
 # misc files in root
-CONTIBUTING.md aaron97neu
+CONTIBUTING.md     aaron97neu
 .markdownlink.json abalmos
-notes.md abalmos
-notes.md abalmos
+notes.md           abalmos
+notes.md           abalmos
 
 # Andrew intially created all the files in .github with some additions by Aaron
-.github abalmos
+.github            abalmos
 .github/CODEOWNERS aaron97neu
 
 # Andrew initally wrote the ansible scripts, with some additions by Aaron
@@ -28,13 +28,13 @@ hardware facastiblancor
 # Andrew intially the installers
 installers aaron97neu
 
-Fabio wrote the cell/can logger containers
-services/can_logger
-services/cell_logger
-services/socketcand
+# Fabio wrote the cell/can logger containers
+services/can_logger   facastiblancor
+services/cell_logger  facastiblancor
+services/socketcand   facastiblancor
 
 # Aaron wrote the gps, db, and oada related containers
-services/can_watchdog
-services/gps2tsdb
-services/oada_upload
-services/postgres
+services/can_watchdog aaron97neu
+services/gps2tsdb     aaron97neu
+services/oada_upload  aaron97neu
+services/postgres     aaron97neu


### PR DESCRIPTION
Adding a codeowners file that tells github who owns what file. The owners of a file will be automatically added as a reviewer to PR's involving their code. Please check it over and make sure your owned files are agreeable and that everything is spelled right. Not sure there is a way I can test this which is a little annoying

Once this is merged, I will have to go into a few of the currently open PR's and edit this file for the additions they are making. #115 for @ericpokeefe 's case and #109 for my containers that I added in that PR