### PR TITLE
Ansible libseccomp2 and kernel locking

### DIFF
--- a/ansible/avena/roles/core/tasks/update.yml
+++ b/ansible/avena/roles/core/tasks/update.yml
@@ -25,8 +25,8 @@
   become: yes
   apt:
     name:
-      - linux-image-armmp
-      - linux-headers-armmp
+      - linux-image-armmp{{ '='+kernel_lock_version if kernel_lock_version is defined }}
+      - linux-headers-armmp{{ '='+kernel_lock_version if kernel_lock_version is defined }}
     state: latest
     default_release: "{{ 'buster-backports' if ansible_distribution_release == 'buster' | default(omit) }}"
   notify: reboot system
@@ -36,8 +36,8 @@
   become: yes
   apt:
     name:
-      - linux-image-amd64
-      - linux-headers-amd64
+      - linux-image-amd64{{ '='+kernel_lock_version if kernel_lock_version is defined }}
+      - linux-headers-amd64{{ '='+kernel_lock_version if kernel_lock_version is defined }}
     state: latest
     default_release: "{{ 'buster-backports' if ansible_distribution_release == 'buster' | default(omit) }}"
   notify: reboot system

--- a/ansible/avena/roles/core/tasks/update.yml
+++ b/ansible/avena/roles/core/tasks/update.yml
@@ -21,27 +21,55 @@
   apt:
     update_cache: yes
 
+- name: Mark the Linux Kernel headers as held (arm)
+  become: yes
+  dpkg_selections:
+    name: linux-headers-armmp
+    selection: "{{ 'hold' if kernel_lock_upgrades is defined and kernel_lock_upgrades is sameas true else 'install' }}"
+  when: ansible_facts.architecture == "armv7l" 
+
+- name: Mark the Linux Kernel image as held (arm)
+  become: yes
+  dpkg_selections:
+    name: linux-image-armmp
+    selection: "{{ 'hold' if kernel_lock_upgrades is defined and kernel_lock_upgrades is sameas true else 'install' }}"
+  when: ansible_facts.architecture == "armv7l"
+
+- name: Mark the Linux Kernel headers as held (x86_64)
+  become: yes
+  dpkg_selections:
+    name: linux-headers-amd64
+    selection: "{{ 'hold' if kernel_lock_upgrades is defined and kernel_lock_upgrades is sameas true else 'install' }}"
+  when: ansible_facts.architecture == "x86_64"
+
+- name: Mark the Linux Kernel image as held (x86_64)
+  become: yes
+  dpkg_selections:
+    name: linux-image-amd64
+    selection: "{{ 'hold' if kernel_lock_upgrades is defined and kernel_lock_upgrades is sameas true else 'install' }}"
+  when: ansible_facts.architecture == "x86_64"
+
 - name: ensure Linux Kernel is up to date (arm)
   become: yes
   apt:
     name:
-      - linux-image-armmp{{ '='+kernel_lock_version if kernel_lock_version is defined }}
-      - linux-headers-armmp{{ '='+kernel_lock_version if kernel_lock_version is defined }}
+      - linux-image-armmp
+      - linux-headers-armmp
     state: latest
     default_release: "{{ 'buster-backports' if ansible_distribution_release == 'buster' | default(omit) }}"
   notify: reboot system
-  when: ansible_facts.architecture == "armv7l"
+  when: ansible_facts.architecture == "armv7l" and (kernel_lock_upgrades is not defined or not kernel_lock_upgrades)
 
 - name: ensure Linux Kernel is up to date (x86_64)
   become: yes
   apt:
     name:
-      - linux-image-amd64{{ '='+kernel_lock_version if kernel_lock_version is defined }}
-      - linux-headers-amd64{{ '='+kernel_lock_version if kernel_lock_version is defined }}
+      - linux-image-amd64
+      - linux-headers-amd64
     state: latest
     default_release: "{{ 'buster-backports' if ansible_distribution_release == 'buster' | default(omit) }}"
   notify: reboot system
-  when: ansible_facts.architecture == "x86_64"
+  when: ansible_facts.architecture == "x86_64" and (kernel_lock_upgrades is not defined or not kernel_lock_upgrades)
 
 - name: ensure base operating system is up to date
   become: yes

--- a/ansible/avena/roles/core/tasks/update.yml
+++ b/ansible/avena/roles/core/tasks/update.yml
@@ -21,28 +21,28 @@
   apt:
     update_cache: yes
 
-- name: Mark the Linux Kernel headers as held (arm)
+- name: Ensure the Linux Kernel headers as marked as held or not according to the kernel_lock_upgrades variable (arm)
   become: yes
   dpkg_selections:
     name: linux-headers-armmp
     selection: "{{ 'hold' if kernel_lock_upgrades is defined and kernel_lock_upgrades is sameas true else 'install' }}"
   when: ansible_facts.architecture == "armv7l" 
 
-- name: Mark the Linux Kernel image as held (arm)
+- name: Ensure the Linux Kernel image as marked as held or not according to the kernel_lock_upgrades variable (arm)
   become: yes
   dpkg_selections:
     name: linux-image-armmp
     selection: "{{ 'hold' if kernel_lock_upgrades is defined and kernel_lock_upgrades is sameas true else 'install' }}"
   when: ansible_facts.architecture == "armv7l"
 
-- name: Mark the Linux Kernel headers as held (x86_64)
+- name: Ensure the Linux Kernel headers as marked as held or not according to the kernel_lock_upgrades variable (x86_64)
   become: yes
   dpkg_selections:
     name: linux-headers-amd64
     selection: "{{ 'hold' if kernel_lock_upgrades is defined and kernel_lock_upgrades is sameas true else 'install' }}"
   when: ansible_facts.architecture == "x86_64"
 
-- name: Mark the Linux Kernel image as held (x86_64)
+- name: Ensure the Linux Kernel image as marked as held or not according to the kernel_lock_upgrades variable (x86_64)
   become: yes
   dpkg_selections:
     name: linux-image-amd64
@@ -68,7 +68,7 @@
       - linux-headers-amd64
     state: latest
     default_release: "{{ 'buster-backports' if ansible_distribution_release == 'buster' | default(omit) }}"
-  notify: reboot system
+#  notify: reboot system
   when: ansible_facts.architecture == "x86_64" and (kernel_lock_upgrades is not defined or not kernel_lock_upgrades)
 
 - name: ensure base operating system is up to date

--- a/ansible/avena/roles/docker/tasks/docker.yml
+++ b/ansible/avena/roles/docker/tasks/docker.yml
@@ -97,6 +97,12 @@
 
 # This is required for debian buster for Alpine docker containers to run
 # properly: https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.13.0#time64_requirements
+# Ensure that the cache is updated before installing anything with apt
+- name: Update apt cache
+  become: yes
+  apt:
+    update_cache: yes
+
 - name: Ensure that proper version of libseccomp2 is installed
   become: yes
   apt:

--- a/ansible/avena/roles/docker/tasks/docker.yml
+++ b/ansible/avena/roles/docker/tasks/docker.yml
@@ -95,6 +95,16 @@
     state: present
   when: ansible_facts.architecture == "armv7l"
 
+# This is required for debian buster for Alpine docker containers to run
+# properly: https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.13.0#time64_requirements
+- name: Ensure that proper version of libseccomp2 is installed
+  become: yes
+  apt:
+    name:
+      - libseccomp2
+    state: present
+    default_release: "{{ 'buster-backports' if ansible_distribution_release == 'buster' | default(omit) }}"
+
 - name: use pip to ensure docker-compose is installed
   become: yes
   command:

--- a/ansible/avena/roles/docker/tasks/docker.yml
+++ b/ansible/avena/roles/docker/tasks/docker.yml
@@ -102,7 +102,7 @@
   apt:
     name:
       - libseccomp2
-    state: present
+    state: latest
     default_release: "{{ 'buster-backports' if ansible_distribution_release == 'buster' | default(omit) }}"
 
 - name: use pip to ensure docker-compose is installed


### PR DESCRIPTION
These fixes will allow the kernel version to be locked and installs the backports version of libsecomp2

Locking the kernel can come in handy for units in remote fields where risky upgrades like kernel upgrades are not desired. This addresses #122 at the most basic level, but could be done much more elegantly and with a few more features
The kernel version can be specified in the host ansible config file with the following line (or similar):
```
kernel_lock_version: '5.9.6-1~bpo10+1'
```


The libseccomp2 fix solves the issue found here: https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.13.0#time64_requirements

@facastiblancor and I are upgrading some of the lab units. If these are successful and all tests pass, we will merge this PR