### PR TITLE
Add: cell_nats service

### DIFF
--- a/.github/workflows/build-and-push-services.yml
+++ b/.github/workflows/build-and-push-services.yml
@@ -19,6 +19,7 @@ jobs:
           - cand
           - j1939d
           - gps-exporter
+          - cell_nats
 
     runs-on: ubuntu-latest
 

--- a/services/cell_nats/Dockerfile
+++ b/services/cell_nats/Dockerfile
@@ -1,0 +1,38 @@
+# BUILDER
+FROM python:3 as builder
+
+WORKDIR /usr/src/app
+
+# Download latest listing of available packages
+RUN apt-get -y update
+
+# Needed for building dbus-python
+RUN apt-get install -y --no-install-recommends python3-pip pkg-config libdbus-1-dev python3-dbus
+
+# Activate virtualenv
+RUN python -m venv /opt/venv
+
+# Make sure we use the virtualenv
+ENV PATH="/opt/venv/bin:$PATH"
+
+# Copy requirements and build with pip
+COPY requirements.txt ./
+RUN pip3 install -r requirements.txt
+
+# RUNTIME
+FROM python:3 as runtime
+
+WORKDIR /usr/src/app
+
+# Install runtime deps
+RUN apt-get -y update && apt-get install -y --no-install-recommends python3-dbus
+
+# Copy compiled venv from builder
+COPY --from=builder /opt/venv /opt/venv
+
+# Make sure we use the virtualenv
+ENV PATH="/opt/venv/bin:$PATH"
+
+# Copy script over and run
+COPY cell_logger.py .
+CMD [ "./cell_nats.py" ]

--- a/services/cell_nats/cell_nats.py
+++ b/services/cell_nats/cell_nats.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+import dbus
+import datetime
+import time
+from pynats2 import NATSClient
+
+def get_signal_stats():
+
+    modem_signal_iface = 'org.freedesktop.ModemManager1.Modem.Signal'
+
+    modem_manager_object = bus.get_object('org.freedesktop.ModemManager1', 
+                                          '/org/freedesktop/ModemManager1')
+    modem_manager_iface = dbus.Interface(modem_manager_object, 
+                                         'org.freedesktop.DBus.ObjectManager')
+
+    modem_data = modem_manager_iface.GetManagedObjects()
+
+#Extract modem path from the DBus data dictionary
+
+    modem_path = list(modem_data.keys())[0]    
+
+#Check if the 'Lte' dictionary has signal values assigned. If no values are
+#found, assume the modem is connected to a 'Umts' network.
+
+    if(list(modem_data[modem_path][modem_signal_iface]['Lte'].keys())):
+        
+        cell_tech = 'Lte'
+
+    else:
+
+        cell_tech = 'Umts'
+
+#Get signal info from the dictionary. If there is no data, assume the modem
+#ID has changed and needs to have the signal info update rate reset.
+
+    try:
+
+        signal_dict = dict(modem_data[modem_path][modem_signal_iface][cell_tech])
+        
+        signal = {}
+
+        for item in signal_dict:
+            # Truncate all floats to 1 decimal point
+            signal[str(item)] = float(f'{signal_dict[item]:.1f}')
+
+        signal["tech"] = cell_tech.lower()
+
+    except(KeyError):
+        
+        set_update_rate(modem_path)
+        
+        return ''
+    
+    return signal
+
+bus = dbus.SystemBus()
+
+
+def set_update_rate(modem_path):
+
+    modem_object = bus.get_object('org.freedesktop.ModemManager1', modem_path)
+    modem_iface = dbus.Interface(modem_object,
+                                 'org.freedesktop.ModemManager1.Modem.Signal')
+    modem_iface.Setup(dbus.UInt32(1))
+
+print("Starting cell_nats")
+
+
+if __name__ == '__main__':
+
+    while(True): 
+        
+        timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        data = get_signal_stats()
+        with NATSClient() as client:
+            for item in data:
+                client.publish(f'cell.{item}', 
+                               payload=bytes(str({'value' : data[item],
+                                                  'time' : timestamp}), 
+                                                  'utf-8'))
+        
+        time.sleep(1) 

--- a/services/cell_nats/docker-compose-example.yml
+++ b/services/cell_nats/docker-compose-example.yml
@@ -1,0 +1,10 @@
+version: '3.9'
+services:
+  cell_nats:
+    build:
+      context: ../cell_nats
+    restart: unless-stopped
+  depends_on:
+    - nats
+  volumes: 
+    - /var/run/dbus:/var/run/dbus:rw

--- a/services/cell_nats/requirements.txt
+++ b/services/cell_nats/requirements.txt
@@ -1,0 +1,2 @@
+dbus-python
+pynats2


### PR DESCRIPTION
This PR adds the cell_nats service, a NATS exported for received cell signal strength metrics as reported by ModemManager. Exposed metrics include: RSSI, RSRQ, RSRP, and SNR for LTE, and RSSI, ECIO and SNR for UMTS (a.k.a 3G).

Metrics are exported though the **_cell.*_** topic, where each metric is a subtopic.

Cell signal metrics are expected to be received as:

```
[#1] Received on "cell.rssi"
{'value': -74.0, 'time': '2021-11-09 19:19:03'}

[#2] Received on "cell.rsrp"
{'value': -97.0, 'time': '2021-11-09 19:19:03'}

[#3] Received on "cell.rsrq"
{'value': -10.0, 'time': '2021-11-09 19:19:03'}

[#4] Received on "cell.snr"
{'value': 10.2, 'time': '2021-11-09 19:19:03'}

[#5] Received on "cell.tech"
{'value': 'lte', 'time': '2021-11-09 19:19:03'}
```

TO DO:

- Test docker container in Toradex and Raspberry Pi test units
- Test container after several sleep/wake cycles.
